### PR TITLE
fix(cell): address code review issues for cell package

### DIFF
--- a/src/main/java/com/emergent/doom/cell/Algotype.java
+++ b/src/main/java/com/emergent/doom/cell/Algotype.java
@@ -7,7 +7,7 @@ package com.emergent.doom.cell;
 public enum Algotype {
     BUBBLE("Local adjacent bidirectional value-based sorting"),
     INSERTION("Prefix left view with conservative left-only swaps"),
-    SELECTION("Ideal target position chasing with long-range swaps");
+    SELECTION("Ideal target position chasing with incremental convergence");
 
     private final String description;
 

--- a/src/main/java/com/emergent/doom/cell/BubbleCell.java
+++ b/src/main/java/com/emergent/doom/cell/BubbleCell.java
@@ -3,23 +3,51 @@ package com.emergent.doom.cell;
 /**
  * Abstract base for Levin cell-view Bubble Sort cells.
  * Baked-in: Algotype.BUBBLE (local adj views/swaps).
- * Domain extends and impls compareTo (value-based).
- * TEMPLATE_BEGIN
- * PURPOSE: Provide Bubble policy foundation (bidirectional local).
- * INPUTS: value (int) - fixed sort key.
- * PROCESS:
- *   STEP[1]: Construct with value.
- *   STEP[2]: Return fixed BUBBLE algotype.
- *   STEP[3]: Domain impls compareTo using value.
- * OUTPUTS: Cell<T> with BUBBLE policy.
- * DEPENDENCIES: Cell interface.
- * TEMPLATE_END
+ * Domain extends and implements compareTo (value-based).
+ *
+ * <p>PURPOSE: Provide Bubble policy foundation (bidirectional local).</p>
+ * <p>INPUTS: value (int) - fixed sort key, sortDirection - ascending or descending.</p>
+ * <p>PROCESS:</p>
+ * <ol>
+ *   <li>Construct with value and optional sort direction.</li>
+ *   <li>Return fixed BUBBLE algotype.</li>
+ *   <li>Domain implements compareTo using value.</li>
+ * </ol>
+ * <p>OUTPUTS: Cell with BUBBLE policy.</p>
+ * <p>DEPENDENCIES: Cell interface, HasSortDirection interface.</p>
+ *
+ * <p>GROUND TRUTH REFERENCE: cell_research/BubbleSortCell.py:54-56</p>
+ * <pre>
+ * if self.reverse_direction:
+ *     return self.value < target if check_right else self.value > target
+ * return self.value > target if check_right else self.value < target
+ * </pre>
  */
-public abstract class BubbleCell<T extends BubbleCell<T>> implements Cell<T> {
+public abstract class BubbleCell<T extends BubbleCell<T>> implements Cell<T>, HasSortDirection {
     protected final int value;  // Fixed Levin value (1-N or domain)
+    protected final SortDirection sortDirection;  // Sort direction for cross-purpose experiments
 
+    /**
+     * Construct a BubbleCell with the specified value and default ASCENDING direction.
+     *
+     * @param value the sort key value
+     */
     protected BubbleCell(int value) {
+        this(value, SortDirection.ASCENDING);
+    }
+
+    /**
+     * Construct a BubbleCell with the specified value and sort direction.
+     *
+     * <p>This constructor enables cross-purpose sorting experiments where
+     * cells in the same array can sort in opposite directions.</p>
+     *
+     * @param value the sort key value
+     * @param sortDirection the sort direction (ASCENDING or DESCENDING)
+     */
+    protected BubbleCell(int value, SortDirection sortDirection) {
         this.value = value;
+        this.sortDirection = sortDirection != null ? sortDirection : SortDirection.ASCENDING;
     }
 
     public int getValue() {
@@ -29,6 +57,11 @@ public abstract class BubbleCell<T extends BubbleCell<T>> implements Cell<T> {
     @Override
     public Algotype getAlgotype() {
         return Algotype.BUBBLE;  // Baked-in concrete impl
+    }
+
+    @Override
+    public SortDirection getSortDirection() {
+        return sortDirection;
     }
 
     // Abstract: Domain provides value comparison

--- a/src/main/java/com/emergent/doom/cell/GenericCell.java
+++ b/src/main/java/com/emergent/doom/cell/GenericCell.java
@@ -19,8 +19,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  * *decreasing* order while the other sorted in *increasing* order."</p>
  *
  * <p>For SELECTION algotype cells, GenericCell maintains an idealPos field that tracks
- * the cell's target position, matching the behavior of SelectionCell. This field starts
- * at 0 and increments when swap attempts are denied, per Levin p.9.</p>
+ * the cell's target position, matching the behavior of SelectionCell. For ascending sort,
+ * this field starts at 0 (leftBoundary) and increments when swap attempts are denied.
+ * For descending sort, it should be initialized to rightBoundary via
+ * {@link HasIdealPosition#updateForBoundary(int, int, boolean)}, per Levin p.9.</p>
  *
  * <p>Usage:
  * <pre>{@code
@@ -188,12 +190,16 @@ public class GenericCell implements Cell<GenericCell>, HasIdealPosition, HasSort
         if (this == obj) return true;
         if (obj == null || getClass() != obj.getClass()) return false;
         GenericCell that = (GenericCell) obj;
-        return value == that.value && algotype == that.algotype;
+        return value == that.value
+            && algotype == that.algotype
+            && sortDirection == that.sortDirection;
     }
 
     @Override
     public int hashCode() {
-        return 31 * value + algotype.hashCode();
+        int result = 31 * value + algotype.hashCode();
+        result = 31 * result + sortDirection.hashCode();
+        return result;
     }
 
     @Override

--- a/src/main/java/com/emergent/doom/cell/HasIdealPosition.java
+++ b/src/main/java/com/emergent/doom/cell/HasIdealPosition.java
@@ -16,7 +16,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Expected outputs: Ideal position values and updates.
  * Data flow: ExecutionEngine queries/updates via these methods during swap decisions.</p>
  *
- * @author opencode
+ * @see SelectionCell
+ * @see GenericCell
  */
 public interface HasIdealPosition {
     /**

--- a/src/main/java/com/emergent/doom/cell/InsertionCell.java
+++ b/src/main/java/com/emergent/doom/cell/InsertionCell.java
@@ -3,23 +3,51 @@ package com.emergent.doom.cell;
 /**
  * Abstract base for Levin cell-view Insertion Sort cells.
  * Baked-in: Algotype.INSERTION (prefix left view, left swaps).
- * Domain extends and impls compareTo.
- * TEMPLATE_BEGIN
- * PURPOSE: Provide Insertion policy foundation (prefix conservative).
- * INPUTS: value (int).
- * PROCESS:
- *   STEP[1]: Construct with value.
- *   STEP[2]: Return fixed INSERTION algotype.
- *   STEP[3]: Domain impls compareTo.
- * OUTPUTS: Cell<T> with INSERTION policy.
- * DEPENDENCIES: Cell interface.
- * TEMPLATE_END
+ * Domain extends and implements compareTo.
+ *
+ * <p>PURPOSE: Provide Insertion policy foundation (prefix conservative).</p>
+ * <p>INPUTS: value (int) - fixed sort key, sortDirection - ascending or descending.</p>
+ * <p>PROCESS:</p>
+ * <ol>
+ *   <li>Construct with value and optional sort direction.</li>
+ *   <li>Return fixed INSERTION algotype.</li>
+ *   <li>Domain implements compareTo.</li>
+ * </ol>
+ * <p>OUTPUTS: Cell with INSERTION policy.</p>
+ * <p>DEPENDENCIES: Cell interface, HasSortDirection interface.</p>
+ *
+ * <p>GROUND TRUTH REFERENCE: cell_research/InsertionSortCell.py:59-61</p>
+ * <pre>
+ * if self.reverse_direction:
+ *     return self.value > self.cells[int(target_position[0])].value
+ * return self.value < self.cells[int(target_position[0])].value
+ * </pre>
  */
-public abstract class InsertionCell<T extends InsertionCell<T>> implements Cell<T> {
+public abstract class InsertionCell<T extends InsertionCell<T>> implements Cell<T>, HasSortDirection {
     protected final int value;
+    protected final SortDirection sortDirection;  // Sort direction for cross-purpose experiments
 
+    /**
+     * Construct an InsertionCell with the specified value and default ASCENDING direction.
+     *
+     * @param value the sort key value
+     */
     protected InsertionCell(int value) {
+        this(value, SortDirection.ASCENDING);
+    }
+
+    /**
+     * Construct an InsertionCell with the specified value and sort direction.
+     *
+     * <p>This constructor enables cross-purpose sorting experiments where
+     * cells in the same array can sort in opposite directions.</p>
+     *
+     * @param value the sort key value
+     * @param sortDirection the sort direction (ASCENDING or DESCENDING)
+     */
+    protected InsertionCell(int value, SortDirection sortDirection) {
         this.value = value;
+        this.sortDirection = sortDirection != null ? sortDirection : SortDirection.ASCENDING;
     }
 
     public int getValue() {
@@ -29,6 +57,11 @@ public abstract class InsertionCell<T extends InsertionCell<T>> implements Cell<
     @Override
     public Algotype getAlgotype() {
         return Algotype.INSERTION;  // Baked-in
+    }
+
+    @Override
+    public SortDirection getSortDirection() {
+        return sortDirection;
     }
 
     @Override

--- a/src/main/java/com/emergent/doom/cell/RemainderCell.java
+++ b/src/main/java/com/emergent/doom/cell/RemainderCell.java
@@ -23,20 +23,33 @@ public class RemainderCell extends BubbleCell<RemainderCell> {
     
     /**
      * IMPLEMENTED: Construct a RemainderCell with target number and position
+     *
+     * <p>Note: The value passed to BubbleCell is derived from the remainder for
+     * compatibility with getValue() calls in execution engines (e.g., isLeftSorted).</p>
      */
     public RemainderCell(BigInteger target, int position) {
-        super(0);  // Dummy value; compareTo overridden to use remainder
+        // Pass remainder as value for getValue() compatibility with execution engines
+        // Validation and calculation done in static helper to ensure super() is called first
+        super(computeRemainderValue(target, position));
+
+        this.target = target;
+        this.position = position;
+        this.remainder = target.mod(BigInteger.valueOf(position));
+    }
+
+    /**
+     * Helper method to compute remainder value with validation.
+     * Called before super() to ensure proper initialization order.
+     */
+    private static int computeRemainderValue(BigInteger target, int position) {
         if (target == null || target.compareTo(BigInteger.ZERO) <= 0) {
             throw new IllegalArgumentException("Target must be positive");
         }
         if (position < 1) {
             throw new IllegalArgumentException("Position must be >= 1");
         }
-
-        this.target = target;
-        this.position = position;
-        // Calculate remainder = target mod position
-        this.remainder = target.mod(BigInteger.valueOf(position));
+        // Using intValue() is safe since remainders are bounded by position (< Integer.MAX_VALUE for typical use)
+        return target.mod(BigInteger.valueOf(position)).intValue();
     }
     
     /**

--- a/src/main/java/com/emergent/doom/cell/SelectionCell.java
+++ b/src/main/java/com/emergent/doom/cell/SelectionCell.java
@@ -4,32 +4,62 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Abstract base for Levin cell-view Selection Sort cells.
- * Baked-in: Algotype.SELECTION (target chasing, long-range).
- * Domain extends and impls compareTo.
- * Note: Contains mutable idealPos state (starts at 0, increments on swap denial per Levin p.9).
- * This breaks cell immutability but is required for Levin's dynamic position chasing.
+ * Baked-in: Algotype.SELECTION (target chasing, incremental convergence).
+ * Domain extends and implements compareTo.
+ *
+ * <p>Note: Contains mutable idealPos state (starts at 0 for ascending, or rightBoundary
+ * for descending). Increments on swap denial per Levin p.9. This breaks cell immutability
+ * but is required for Levin's dynamic position chasing.</p>
  *
  * <p><strong>Thread Safety:</strong> The idealPos field uses {@link AtomicInteger}
  * for thread-safe access in parallel execution mode.</p>
  *
- * TEMPLATE_BEGIN
- * PURPOSE: Provide Selection policy foundation (goal-directed).
- * INPUTS: value (int).
- * PROCESS:
- *   STEP[1]: Construct with value.
- *   STEP[2]: Return fixed SELECTION algotype.
- *   STEP[3]: Domain impls compareTo.
- * OUTPUTS: Cell<T> with SELECTION policy.
- * DEPENDENCIES: Cell interface; internal idealPos state and accessors.
- * TEMPLATE_END
+ * <p>PURPOSE: Provide Selection policy foundation (goal-directed).</p>
+ * <p>INPUTS: value (int) - fixed sort key, sortDirection - ascending or descending.</p>
+ * <p>PROCESS:</p>
+ * <ol>
+ *   <li>Construct with value and optional sort direction.</li>
+ *   <li>Return fixed SELECTION algotype.</li>
+ *   <li>Domain implements compareTo.</li>
+ * </ol>
+ * <p>OUTPUTS: Cell with SELECTION policy.</p>
+ * <p>DEPENDENCIES: Cell interface, HasIdealPosition, HasSortDirection interfaces.</p>
+ *
+ * <p>GROUND TRUTH REFERENCE: cell_research/SelectionSortCell.py:11-14</p>
+ * <pre>
+ * if self.reverse_direction:
+ *     self.ideal_position = right_boundary
+ * else:
+ *     self.ideal_position = left_boundary
+ * </pre>
  */
-public abstract class SelectionCell<T extends SelectionCell<T>> implements Cell<T>, HasIdealPosition {
+public abstract class SelectionCell<T extends SelectionCell<T>> implements Cell<T>, HasIdealPosition, HasSortDirection {
     protected final int value;
-    private final AtomicInteger idealPos;  // Thread-safe: starts at 0, increments on swap denial per Levin p.9
+    protected final SortDirection sortDirection;  // Sort direction for cross-purpose experiments
+    private final AtomicInteger idealPos;  // Thread-safe: starts at 0 for ascending, increments on swap denial
 
+    /**
+     * Construct a SelectionCell with the specified value and default ASCENDING direction.
+     *
+     * @param value the sort key value
+     */
     protected SelectionCell(int value) {
+        this(value, SortDirection.ASCENDING);
+    }
+
+    /**
+     * Construct a SelectionCell with the specified value and sort direction.
+     *
+     * <p>Note: The idealPos is initialized to 0. For descending sort, call
+     * {@link #updateForBoundary(int, int, boolean)} to set it to rightBoundary.</p>
+     *
+     * @param value the sort key value
+     * @param sortDirection the sort direction (ASCENDING or DESCENDING)
+     */
+    protected SelectionCell(int value, SortDirection sortDirection) {
         this.value = value;
-        this.idealPos = new AtomicInteger(0);  // Levin: initial ideal position is most left (0)
+        this.sortDirection = sortDirection != null ? sortDirection : SortDirection.ASCENDING;
+        this.idealPos = new AtomicInteger(0);  // Levin: initial ideal position is most left (0) for ascending
     }
 
     public int getValue() {
@@ -69,6 +99,11 @@ public abstract class SelectionCell<T extends SelectionCell<T>> implements Cell<
     @Override
     public Algotype getAlgotype() {
         return Algotype.SELECTION;  // Baked-in
+    }
+
+    @Override
+    public SortDirection getSortDirection() {
+        return sortDirection;
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fixes issues identified in the cell package code review comparing against `REQUIREMENTS.md` and `cell_research` Python reference implementation.

### P0 Fixes (Critical)

- **RemainderCell.getValue()** returned `0` instead of actual remainder
  - Added static helper `computeRemainderValue()` for validation before `super()` call
  - Fixes `isLeftSorted()` in `LockBasedExecutionEngine` for INSERTION mode

- **BubbleCell** now implements `HasSortDirection` for cross-purpose experiments
  - Added `sortDirection` field and `getSortDirection()`
  - Added overloaded constructor with `SortDirection` parameter

- **InsertionCell** now implements `HasSortDirection` for cross-purpose experiments
  - Added `sortDirection` field and `getSortDirection()`
  - Added overloaded constructor with `SortDirection` parameter

- **SelectionCell** now implements `HasSortDirection` for consistency
  - Added `sortDirection` field and `getSortDirection()`
  - Updated documentation about `idealPos` initialization for descending sort

### P2 Fixes (Medium)

- **GenericCell.equals()**: Now includes `sortDirection` in equality check
- **GenericCell.hashCode()**: Updated to include `sortDirection`

### P3 Fixes (Low)

- **Algotype.SELECTION**: Fixed misleading "long-range swaps" description → "incremental convergence"
- **GenericCell**: Fixed documentation about `idealPos` for descending sort
- **HasIdealPosition**: Replaced placeholder `@author` with `@see` references

### Files Changed (7)

| File | Lines Changed |
|------|---------------|
| `RemainderCell.java` | +25 |
| `BubbleCell.java` | +33 |
| `InsertionCell.java` | +33 |
| `SelectionCell.java` | +35 |
| `GenericCell.java` | +8 |
| `Algotype.java` | +1 |
| `HasIdealPosition.java` | +2 |

## Test plan

- [x] All 259 existing tests pass
- [x] Compile succeeds with no warnings
- [ ] Manual verification of cross-purpose sorting with new `HasSortDirection` support

## References

- REQUIREMENTS.md Section 2.2 (CellStatus), 3.2 (Selection), 8.2 (Cross-Purpose)
- cell_research/modules/multithread/BubbleSortCell.py:54-56
- cell_research/modules/multithread/SelectionSortCell.py:11-14

🤖 Generated with [Claude Code](https://claude.com/claude-code)