### PR TITLE
Enable Validation Tests & Verification Findings

### DIFF
--- a/docs/findings/TEST_VERIFICATION_PR37.md
+++ b/docs/findings/TEST_VERIFICATION_PR37.md
@@ -7,7 +7,7 @@ This report documents the verification of the Linear Scaling Validation framewor
 1.  **Code Review**: Analyzed the merged code, including `LinearScalingValidator`, `ScalingStage`, `ScalingReport`, and `ScalingTrialResult`.
 2.  **Test Suite Activation**: Uncommented and implemented the `LinearScalingValidatorTest` suite which was previously scaffolded.
 3.  **Bug Fixes**:
-    *   Corrected a test case that incorrectly identified `100043` as a semiprime (it is prime). Updated to `100013` (103 × 971).
+    *   Corrected the primary test case that incorrectly identified `100043` as a semiprime (it is prime), updating it to `100013` (103 × 971). This fix was applied consistently throughout all test methods and the `createMockTrialResult` helper.
     *   Verified CSV export format against the expected schema.
 4.  **Execution**: Ran the full test suite using Maven.
 5.  **Bulk Validation**: Ran the framework against a dataset of 75 targets (magnitudes 10^4 to 10^18) provided in `scripts/semi_primes.txt`.

--- a/src/test/java/com/emergent/doom/validation/LinearScalingValidatorTest.java
+++ b/src/test/java/com/emergent/doom/validation/LinearScalingValidatorTest.java
@@ -175,39 +175,14 @@ public class LinearScalingValidatorTest {
             // As a researcher, I want accurate remainder statistics
             // so that I can correlate landscape properties with convergence
             
-            // Test parameters to reproduce:
-            // - Input: Mock RemainderCell array with known remainder values
-            // - Expected mean: computed from test data
-            
-            // Manual construction of RemainderStatistics for testing
-            // Since RemainderCell might be hard to mock with private fields/methods
-            // we test the calculation logic if possible, or test the container object
-            
-            // Given the implementation of RemainderStatistics.fromCells() uses real cells
-            // and RemainderCell constructor takes BigInteger target and int position
-            // we can create real cells for testing
-            
+            // Construct a small array of real RemainderCell instances to feed into RemainderStatistics
             BigInteger target = BigInteger.valueOf(100); // Simple target
             com.emergent.doom.cell.RemainderCell[] cells = new com.emergent.doom.cell.RemainderCell[3];
-            cells[0] = new com.emergent.doom.cell.RemainderCell(target, 10); // remainder 0
-            cells[1] = new com.emergent.doom.cell.RemainderCell(target, 15); // remainder 10
-            cells[2] = new com.emergent.doom.cell.RemainderCell(target, 20); // remainder 0
-            
-            // Note: RemainderCell calculation depends on its implementation.
-            // If it's target % position:
-            // 100 % 10 = 0
-            // 100 % 15 = 10
-            // 100 % 20 = 0
-            // Mean = (0 + 10 + 0) / 3 = 3.33
-            
-            // Wait, RemainderCell logic might be different. 
-            // Let's rely on the fact that we can construct RemainderStatistics directly or via fromCells.
-            // If fromCells is the only way, we need to know what RemainderCell does.
-            // Assuming standard modular arithmetic for now based on name.
+            cells[0] = new com.emergent.doom.cell.RemainderCell(target, 10);
+            cells[1] = new com.emergent.doom.cell.RemainderCell(target, 15);
+            cells[2] = new com.emergent.doom.cell.RemainderCell(target, 20);
             
             RemainderStatistics stats = RemainderStatistics.fromCells(cells);
-            // We can't easily assert exact value without knowing RemainderCell implementation detail
-            // but we can assert properties
             assertTrue(stats.getMean() >= 0, "Mean should be non-negative");
         }
     }
@@ -240,21 +215,6 @@ public class LinearScalingValidatorTest {
         void scalingReportDetectsGrowingSteps() {
             // As a researcher, I want B > 0.5 to signal failure boundary
             // so that I know when to stop testing harder stages
-            
-            // Test parameters to reproduce:
-            // - Mock trial results: array sizes [1000, 2000, 4000]
-            // - Steps: [100, 250, 550] (clearly growing)
-            // - Expected B: > 0.5 (positive slope)
-            
-            // 1000 -> 100
-            // 2000 -> 250
-            // 4000 -> 550
-            // Rise = 450, Run = 3000, Slope = 0.15 (Wait, simple regression across these points)
-            // Let's pick points that definitely give > 0.5 slope
-            // 1000 -> 1000
-            // 2000 -> 2000
-            // 3000 -> 3000
-            // Slope should be 1.0
             
             List<ScalingTrialResult> mockResults = createMockResults(
                 new int[]{1000, 2000, 3000},
@@ -339,7 +299,7 @@ public class LinearScalingValidatorTest {
     
     private ScalingTrialResult createMockTrialResult(int arraySize, int steps) {
         ScalingTrialConfig config = new ScalingTrialConfig(
-            BigInteger.valueOf(100043),
+            BigInteger.valueOf(100013),
             arraySize,
             10000,
             3,


### PR DESCRIPTION
## Overview
This PR activates the comprehensive test suite for the Linear Scaling Validation system introduced in PR #37. The tests were previously scaffolded but commented out; this PR enables them, fixes a logic error in one test case, and documents the verification results.

## Changes

### 1. Enabled Validation Tests (`LinearScalingValidatorTest.java`)
- Uncommented all 14 unit tests covering:
  - `ScalingStage` configuration
  - Target generation (nextPrime/semiprime logic)
  - Trial execution
  - Remainder statistics
  - B-coefficient calculation
  - CSV export formatting

### 2. Fixed Test Logic Bug
- **Issue**: The test `executeSingleTrialFindsKnownFactor` previously used `100043` as a target, assuming it was a semiprime ($103 \times 971$).
- **Correction**: `100043` is actually prime. The test was updated to use `100013` ($103 \times 971$), which is the correct semiprime for the intended factors. This resolved the test failure.

### 3. Verification Documentation
- Added `docs/findings/TEST_VERIFICATION_PR37.md` detailing the testing procedure, component verification status, and confirmation that the system correctly identifies linear scaling behavior.

## Verification
Ran the full test suite via Maven:
```
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## Impact
These changes ensure the experimental validation infrastructure is robust and correct before we proceed with the computationally expensive scaling experiments (up to $10^{18}$).