### PR TITLE
Guard snapshot algotype distributions without metadata

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,5 +69,8 @@ PR [#113](https://github.com/zfifteen/emergent-doom-engine/pull/113) implemented
 - Replaced `SynchronousExecutionEngine` with `CellBasedExecutionEngine`
 - Produces characteristic 18.30% aggregation variance signature matching Levin research
 
+### Snapshot Metadata Guardrails (January 2026)
+- Skip invalid algotype labels when computing snapshot type distributions to avoid export-time crashes when metadata is unavailable.
+
 ---
 *Last updated: January 6, 2026*

--- a/src/main/java/com/emergent/doom/probe/StepSnapshot.java
+++ b/src/main/java/com/emergent/doom/probe/StepSnapshot.java
@@ -128,6 +128,9 @@ public class StepSnapshot<T extends Cell<T>> {
         Map<Algotype, Integer> dist = new HashMap<>();
         for (Object[] t : types) {
             int label = (Integer) t[1];
+            if (label < 0 || label >= Algotype.values().length) {
+                continue;
+            }
             Algotype type = Algotype.values()[label];
             dist.merge(type, 1, Integer::sum);
         }
@@ -135,6 +138,12 @@ public class StepSnapshot<T extends Cell<T>> {
     }
 
     public boolean hasCellTypeDistribution() {
-        return true;
+        for (Object[] t : types) {
+            int label = (Integer) t[1];
+            if (label >= 0 && label < Algotype.values().length) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent export-time crashes when snapshot metadata is missing or contains invalid algotype labels by making distribution computation defensive.
- Ensure backward-compatible snapshot APIs remain stable even when `types` metadata is incomplete.
- Make the snapshot availability check reflect whether any valid algotype labels are present.

### Description
- In `StepSnapshot.getCellTypeDistribution()` skip labels that are out of range of `Algotype.values()` before mapping to an `Algotype` instance. 
- In `StepSnapshot.hasCellTypeDistribution()` return `true` only if at least one valid algotype label exists in `types` instead of always returning `true`.
- Add documentation note `Snapshot Metadata Guardrails` to `docs/README.md` describing the guard behavior.

### Testing
- Ran `mvn test` which completed with `BUILD SUCCESS` and all automated tests passing. 
- Test summary: `Tests run: 235, Failures: 0, Errors: 0, Skipped: 26`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f9e3a23c083299d1d7dbe7a7405a2)